### PR TITLE
Make it work with hash multiple times. e.g. gulp.watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var es        = require('event-stream'),
     through   = require('through'),
     gutil     = require('gulp-util'),
-    hasher    = require('crypto').createHash('sha256'),
+    crypto    = require('crypto'),
     path      = require('path'),
     lineBreak = '\n';
 
@@ -14,6 +14,7 @@ function manifest(options) {
 
   var filename = options.filename || 'app.manifest';
   var exclude = [].concat(options.exclude || []);
+  var hasher = crypto.createHash('sha256');
 
   if (options.timestamp) {
     contents.push('# Time: ' + new Date());

--- a/test/main.js
+++ b/test/main.js
@@ -64,4 +64,21 @@ describe('gulp-manifest', function() {
     fakeFiles.forEach(stream.write.bind(stream));
     stream.end();
   });
+
+  it('Should work with hash multiple times', function (done) {
+    var pending = 2;
+    function generateWithHash() {
+      var stream = manifestPlugin({ hash: true });
+      stream.on('data', function (data) {
+        data.contents.toString().should.contain('# hash: ');
+      });
+      stream.once('end', function () {
+        if (--pending <= 0) done();
+      });
+      fakeFiles.forEach(stream.write.bind(stream));
+      stream.end();
+    }
+    generateWithHash();
+    generateWithHash();
+  });
 });


### PR DESCRIPTION
Now this plugin doesn't work with `gulp.watch` when `hash` option is set true. That is because `TypeError: HashUpdate fail` is thrown when `hasher` is reused after called `digest()`.

This patch fixes the issue calling `createHash()` every time the exported function is called.
