### PR TITLE
Add option for absolute path names in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Adds a sha256 hash of all `src` files (actual contents) as a comment.
 
 This will ensure that application cache invalidates whenever actual file contents change (it's recommented to set `timestamp` to `false` when `hash` is used).
 
+#### options.absolutePaths
+Type: `Boolean`
+Default: `undefined`
+
+Prefer absolute file paths in the manifest file, e.g: `/js/app.js` rather than `js/app.js`.
+
 ### Usage Example
 
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,13 @@ function manifest(options) {
       return;
     }
 
-    contents.push(encodeURI(file.relative));
+    var fileName = file.relative;
+
+    if (options.absolutePaths) {
+      fileName = '/' + fileName;
+    }
+
+    contents.push(encodeURI(fileName));
 
     if (options.hash) {
       hasher.update(file.contents, 'binary');


### PR DESCRIPTION
So the manifest can contain, for example:

```
/app.js
```