### PR TITLE
Encode separately the components of the FALLBACK section

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,15 @@ function manifest(options) {
       contents.push(lineBreak);
       contents.push('FALLBACK:');
       options.fallback.forEach(function (file) {
-        contents.push(encodeURI(file));
+        var firstSpace = file.indexOf(' ');
+        if(firstSpace === -1) {
+          return gutil.log('Invalid format for FALLBACK entry', file);
+        }
+        contents.push(
+          encodeURI(file.substring(0, firstSpace)) +
+          ' ' +
+          encodeURI(file.substring(firstSpace + 1))
+        );
       });
     }
 
@@ -84,7 +92,7 @@ function manifest(options) {
       cwd: cwd,
       base: cwd,
       path: path.join(cwd, filename),
-      contents: new Buffer(contents.join(lineBreak)),
+      contents: new Buffer(contents.join(lineBreak))
     });
 
     this.emit('data', manifestFile);

--- a/test/main.js
+++ b/test/main.js
@@ -102,4 +102,22 @@ describe('gulp-manifest', function() {
     generateWithHash();
     generateWithHash();
   });
+
+  it('Should generate a valid fallback section', function(done) {
+    var stream = manifestPlugin({
+      filename: 'cache.manifest',
+      fallback: ['/ /offline.html'],
+      network: ['http://*', 'https://*', '*']
+    });
+
+    stream.on('data', function(data) {
+      data.should.be.an.instanceOf(gutil.File);
+      data.relative.should.eql('cache.manifest');
+
+      var contents = data.contents.toString();
+      contents.should.contain('FALLBACK:\n/ /offline.html');
+    });
+    stream.once('end', done);
+    stream.end();
+  });
 });


### PR DESCRIPTION
Right now any space in the fallback section are URI encoded
so things like this:
`/ /offline.html`
will result in:
`/%20/offline.html`
This fix encodes the two urls separately
