### PR TITLE
Let "exclude" configuration can support regular expressions,extended glob matching,"Globstar" **

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var es        = require('event-stream'),
     crypto    = require('crypto'),
     path      = require('path'),
     slash     = require('slash'),
+    minimatch     = require('minimatch'),
     lineBreak = '\n';
 
 function manifest(options) {

--- a/index.js
+++ b/index.js
@@ -38,9 +38,12 @@ function manifest(options) {
     if (file.isNull())   return;
     if (file.isStream()) return this.emit('error', new gutil.PluginError('gulp-manifest',  'Streaming not supported'));
 
-    if (exclude.indexOf(file.relative) >= 0) {
-      return;
-    }
+    for (var i = 0; i < exclude.length; i++) {
+          if(minimatch(file.relative, exclude[i])){
+              //console.log(exclude[i] + ":" + file.relative);  //print the path of excluded file
+              return;
+          }
+      }
 
     contents.push(encodeURI(slash(file.relative)));
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ function manifest(options) {
 
     for (var i = 0; i < exclude.length; i++) {
           if(minimatch(file.relative, exclude[i])){
-              //console.log(exclude[i] + ":" + file.relative);  //print the path of excluded file
               return;
           }
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "event-stream": "~3.0.20",
     "through": "~2.3.4",
     "gulp-util": "~2.2.6",
-    "slash": "^0.1.1"
+    "slash": "^0.1.1",
+    "minimatch": "~2.0.1"
   }
 }


### PR DESCRIPTION
Use minimatch to let "exclude" configuration can support regular expressions,extended glob matching,"Globstar" **

exam:
exclude: ['app.manifest','**/*.json',"*.appcache"]