### PR TITLE
Removed http://*, https://*  from the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This will ensure that application cache invalidates whenever actual file content
         .pipe(manifest({
           hash: true,
           preferOnline: true,
-          network: ['http://*', 'https://*', '*'],
+          network: ['*'],
           filename: 'app.manifest',
           exclude: 'app.manifest'
          }))
@@ -109,8 +109,6 @@ This will ensure that application cache invalidates whenever actual file content
     some_files/about.html
 
     NETWORK:
-    http://*
-    https://*
     *
 
     # hash: 76f0ef591f999871e1dbdf6d5064d1276d80846feeef6b556f74ad87b44ca16a


### PR DESCRIPTION
Hi,

I think the example in README should not include http://*, https://* network entries because the resulting manifest is not valid according to the http://manifest-validator.com/ and to my understanding it's not valid according to the standard http://www.w3.org/TR/html5/browsers.html#appcache as well.

If I am wrong, could you please explain why these entries are needed (maybe it's required by some browsers etc?). Thanks!

Best,
Alex