### PR TITLE
Patch fallback to allow string - resolves #26

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,9 @@ function manifest(options) {
     if (options.fallback) {
       contents.push(lineBreak);
       contents.push('FALLBACK:');
+      if (typeof options.fallback === 'string') {
+        options.fallback = [options.fallback];
+      }
       options.fallback.forEach(function (file) {
         var firstSpace = file.indexOf(' ');
         if(firstSpace === -1) {


### PR DESCRIPTION
According to the readme the `fallback` option accepts `string` or `array`. Currently everything fails if a string is given, so the quick fix is to check if the value is a string, and create an array with that string.

This resolves issue #26 