### PR TITLE
fix unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var through   = require('through'),
     crypto    = require('crypto'),
     path      = require('path'),
     minimatch = require('minimatch'),
+    slash     = require('slash'),
     lineBreak = '\n';
 
 function manifest(options) {
@@ -50,9 +51,9 @@ function manifest(options) {
     }
 
     prefix = options.prefix || '';
-    filepath = prefix + file.relative;
+    filepath = prefix + slash(file.relative);
 
-    contents.push(encodeURI(file.relative));
+    contents.push(encodeURI(slash(filepath)));
 
     if (options.hash) {
       hasher.update(file.contents, 'binary');

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ function manifest(options) {
 
   options = options || {};
 
+  if(options.basePath) {
+    gutil.log('basePath option is deprecated. Consider using gulp.src base instead: https://github.com/gulpjs/gulp/blob/master/docs/API.md#optionsbase');
+  }
+
   filename = options.filename || 'app.manifest';
   exclude = Array.prototype.concat(options.exclude || []);
   hasher = crypto.createHash('sha256');
@@ -51,9 +55,16 @@ function manifest(options) {
     }
 
     prefix = options.prefix || '';
-    filepath = prefix + slash(file.relative);
+    filepath = slash(file.relative);
 
-    contents.push(encodeURI(slash(filepath)));
+    if(options.basePath) { // deprecated
+      var relative = path.relative(file.base, __dirname);
+      filepath = filepath.replace(new RegExp('^' + path.join(relative, options.basePath)), '');
+    }
+
+    filepath = prefix + filepath;
+
+    contents.push(encodeURI(filepath));
 
     if (options.hash) {
       hasher.update(file.contents, 'binary');

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "gulp-util": "~2.2.6",
     "minimatch": "~2.0.1",
-    "through": "~2.3.4",
-    "slash": "^1.0.0"
+    "slash": "^1.0.0",
+    "through": "~2.3.4"
   },
   "bugs": {
     "url": "https://github.com/hillmanov/gulp-manifest/issues"

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "devDependencies": {
     "event-stream": "^3.1.7",
     "mocha": "~1.16.2",
-    "should": "~2.1.1",
-    "slash": "^1.0.0"
+    "should": "~2.1.1"
   },
   "dependencies": {
     "gulp-util": "~2.2.6",
     "minimatch": "~2.0.1",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "slash": "^1.0.0"
   },
   "bugs": {
     "url": "https://github.com/hillmanov/gulp-manifest/issues"

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
   "devDependencies": {
     "event-stream": "^3.1.7",
     "mocha": "~1.16.2",
-    "should": "~2.1.1"
+    "should": "~2.1.1",
+    "slash": "^1.0.0"
   },
   "dependencies": {
-    "through": "~2.3.4",
     "gulp-util": "~2.2.6",
-    "minimatch": "~2.0.1"
+    "minimatch": "~2.0.1",
+    "through": "~2.3.4"
   },
   "bugs": {
     "url": "https://github.com/hillmanov/gulp-manifest/issues"

--- a/test/main.js
+++ b/test/main.js
@@ -58,11 +58,14 @@ describe('gulp-manifest', function() {
         hash: false
     });
 
+    var contents = '';
     stream.on('data', function(data) {
-      var contents = data.contents.toString();
-      contents.should.contain('fixture/hello.js');
+      contents += data.contents.toString();
     });
-    stream.once('end', done);
+    stream.once('end', function() {
+      contents.should.contain('fixture/hello.js');
+      done();
+    });
 
     stream.write(new gutil.File({
         path: path.resolve('test\\fixture\\hello.js'),
@@ -79,14 +82,17 @@ describe('gulp-manifest', function() {
       exclude: ['file2.js', 'file4.js'],
     });
 
+    var contents = '';
     stream.on('data', function(data) {
-      var contents = data.contents.toString();
+      contents += data.contents.toString();
+    });
+    stream.once('end', function() {
       contents.should.contain('file1.js');
       contents.should.not.contain('file2.js');
       contents.should.contain('file3.js');
       contents.should.not.contain('file4.js');
+      done();
     });
-    stream.once('end', done);
 
     fakeFiles.forEach(stream.write.bind(stream));
     stream.end();
@@ -123,14 +129,18 @@ describe('gulp-manifest', function() {
       network: ['http://*', 'https://*', '*']
     });
 
+    var contents = '',
+        relatives = [];
     stream.on('data', function(data) {
       data.should.be.an.instanceOf(gutil.File);
-      data.relative.should.eql('cache.manifest');
-
-      var contents = data.contents.toString();
-      contents.should.contain('FALLBACK:\n/ /offline.html');
+      relatives.push(data.relative);
+      contents += data.contents.toString();
     });
-    stream.once('end', done);
+    stream.once('end', function() {
+      contents.should.contain('FALLBACK:\n/ /offline.html');
+      relatives.indexOf('cache.manifest').should.not.be.equal(-1);
+      done();
+    });
     stream.end();
   });
 
@@ -140,11 +150,14 @@ describe('gulp-manifest', function() {
           prefix: prefix
         });
 
+    var contents = '';
     stream.on('data', function(data) {
-      var contents = data.contents.toString();
-      contents.should.contain(prefix);
+      contents += data.contents.toString();
     });
-    stream.once('end', done);
+    stream.once('end', function() {
+      contents.should.contain(prefix);
+      done();
+    });
 
     stream.write(new gutil.File({
       path: path.resolve('test\\fixture\\hello.js'),
@@ -160,12 +173,15 @@ describe('gulp-manifest', function() {
     var filepath = 'test\\fixture\\hello.js',
         stream = manifestPlugin();
 
+    var contents = '';
     stream.on('data', function(data) {
-      var contents = data.contents.toString();
-      contents.should.contain(slash(filepath));
+      contents += data.contents.toString();
     });
 
-    stream.once('end', done);
+    stream.once('end', function() {
+      contents.should.contain(slash(filepath));
+      done();
+    });
 
     stream.write(new gutil.File({
       path: path.resolve(filepath),
@@ -183,12 +199,15 @@ describe('gulp-manifest', function() {
           basePath: basePath
         });
 
+    var contents = '';
     stream.on('data', function(data) {
-      var contents = data.contents.toString();
-      contents.should.not.contain(basePath);
+      contents += data.contents.toString();
     });
 
-    stream.once('end', done);
+    stream.once('end', function() {
+      contents.should.not.contain(basePath);
+      done();
+    });
 
     stream.write(new gutil.File({
       path: path.resolve(basePath + '\\test\\fixture\\hello.js'),
@@ -209,11 +228,15 @@ describe('gulp-manifest', function() {
       preferOnline: true
     });
 
+    var contents = '', relatives = [];
     stream.on('data', function(data) {
       data.should.be.an.instanceOf(gutil.File);
-      data.relative.should.eql('cache.manifest');
 
-      var contents = data.contents.toString();
+      relatives.push(data.relative);
+      contents += data.contents.toString();
+    });
+
+    stream.once('end', function() {
       contents.should.startWith('CACHE MANIFEST');
       contents.should.contain('CACHE:');
       contents.should.contain('file1.js');
@@ -225,9 +248,10 @@ describe('gulp-manifest', function() {
       contents.should.not.contain('exclude');
       contents.should.contain('include1.js');
       contents.should.contain('include2.js');
-    });
 
-    stream.once('end', done);
+      relatives.indexOf('cache.manifest').should.not.be.equal(-1);
+      done();
+    });
 
     fakeFiles.forEach(stream.write.bind(stream));
 


### PR DESCRIPTION
- Fixes the unit tests on Unix and Windows and helps investigating #34
- Bring back `basePath` option with deprecation notice

Using `gulp.src.base` option is preferred over `gulp-manifest.basePath`, because it's already achieved globally before piping the stream to this plugin. Assets coming from different source directories can be concatenated with proper paths using [merge-stream](https://github.com/grncdr/merge-stream), eg.

```javascript
var mergeStream = require('merge-stream');
var manifestPlugin = require('gulp-manifest');
return mergeStream(
  gulp.src('dist/**', {
    base: 'dist/'
  }),
  gulp.src('assets/**', {
    base: 'assets/'
  })
).
pipe(manifestPlugin())
...
```
