### PR TITLE
fix Windows file paths including %5C instead of /

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -78,6 +78,31 @@ describe('gulp-manifest', function() {
     stream.end();
   });
 
+  it('Should work with Unix file paths', function(done) {
+    var stream = manifestPlugin({
+        hash: false
+    });
+
+    var contents = '';
+    stream.on('data', function(data) {
+      contents += data.contents.toString();
+    });
+    stream.once('end', function() {
+      contents.should.contain('fixture/hello.js');
+      done();
+    });
+
+    stream.write(new gutil.File({
+        path: path.resolve('test/fixture/hello.js'),
+        cwd: path.resolve('test/'),
+        base: path.resolve('test/'),
+        contents: new Buffer('notimportant')
+    }));
+
+    stream.end();
+  });
+
+
   it('Should exclude multiple files', function(done) {
     var stream = manifestPlugin({
       exclude: ['file2.js', 'file4.js'],


### PR DESCRIPTION
fixes #39 

- [x] test forward slash escaped paths on Windows
- [ ] reproduce error described in #39 
- [ ] automate running tests on Windows instances (e.g. *AppVeyor.com*)