### PR TITLE
Fixing Issue #46 Timestamp default with new Unit Tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var through   = require('through'),
     lineBreak = '\n';
 
 function manifest(options) {
-  var filename, exclude, cache, include, hasher, cwd, contents;
+  var filename, exclude, cache, include, hasher, cwd, contents, timestamp;
 
   options = options || {};
 
@@ -24,10 +24,11 @@ function manifest(options) {
   hasher = crypto.createHash('sha256');
   cwd = process.cwd();
   contents = [];
+  timestamp = options.timestamp || (typeof(options.timestamp) === 'undefined');
 
   contents.push('CACHE MANIFEST');
 
-  if (options.timestamp) {
+  if (timestamp) {
     contents.push('# Time: ' + new Date());
   }
 

--- a/test/main.js
+++ b/test/main.js
@@ -511,4 +511,45 @@ describe('gulp-manifest', function() {
     fakeFiles.forEach(stream.write.bind(stream));
     stream.end();
   });
+
+  it('Should enable timestamp by default', function(done) {
+    var stream = manifestPlugin({
+      filename: 'cache.manifest',
+      cache: ['foo.html', 'bar.js'],
+    });
+
+    stream.on('data', function(data) {
+      data.should.be.an.instanceOf(gutil.File);
+      data.relative.should.eql('cache.manifest');
+
+      var contents = data.contents.toString();
+      contents.should.startWith('CACHE MANIFEST');
+      contents.should.contain('# Time: ');
+    });
+    stream.once('end', done);
+
+    fakeFiles.forEach(stream.write.bind(stream));
+    stream.end();
+  });
+
+  it('Should disable timestamp when specified', function(done) {
+    var stream = manifestPlugin({
+      filename: 'cache.manifest',
+      cache: ['foo.html', 'bar.js'],
+      timestamp: false
+    });
+
+    stream.on('data', function(data) {
+      data.should.be.an.instanceOf(gutil.File);
+      data.relative.should.eql('cache.manifest');
+
+      var contents = data.contents.toString();
+      contents.should.startWith('CACHE MANIFEST');
+      contents.should.not.contain('# Time: ');
+    });
+    stream.once('end', done);
+
+    fakeFiles.forEach(stream.write.bind(stream));
+    stream.end();
+  });
 });


### PR DESCRIPTION
Adding timestamp check for undefined to allow option to default to true
as specified in the documentation.
Updating unit tests to check timestamp is created by default and turned off by options.
