### PR TITLE
remove dependency on gulp-util

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# gulp-manifest
+# gulp-manifest (2)
+
+Same as gulp-manifest by Scott Hillman (see below), but with gutil removed as a dependency. This package is only for circumventing an issue with gutil.
+
 > Generate HTML5 Cache Manifest files. Submitted by [Scott Hillman](https://github.com/hillmanov/).
 
 Big thanks to [Gunther Brunner](https://github.com/gunta/) for writing the [grunt-manifest](https://github.com/gunta/grunt-manifest) plugin. This plugin was heavily influenced by his great work.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gulp-manifest (2)
+# gulp-manifest3
 
 Same as gulp-manifest by Scott Hillman (see below), but with gutil removed as a dependency. This package is only for circumventing an issue with gutil.
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 "use strict";
 
 var through   = require('through'),
-    gutil     = require('gulp-util'),
-    crypto    = require('crypto'),
-    path      = require('path'),
-    minimatch = require('minimatch'),
-    slash     = require('slash'),
-    lineBreak = '\n';
+    log         = require('fancy-log'),
+    PluginError = require('plugin-error'),
+    Vinyl       = require('vinyl'),
+    crypto      = require('crypto'),
+    path        = require('path'),
+    minimatch   = require('minimatch'),
+    slash       = require('slash'),
+    lineBreak   = '\n';
 
 function manifest(options) {
   var filename, exclude, cache, include, hasher, cwd, contents, timestamp;
@@ -14,7 +16,7 @@ function manifest(options) {
   options = options || {};
 
   if(options.basePath) {
-    gutil.log('basePath option is deprecated. Consider using gulp.src base instead: https://github.com/gulpjs/gulp/blob/master/docs/API.md#optionsbase');
+    log('basePath option is deprecated. Consider using gulp.src base instead: https://github.com/gulpjs/gulp/blob/master/docs/API.md#optionsbase');
   }
 
   filename = options.filename || 'app.manifest';
@@ -53,7 +55,7 @@ function manifest(options) {
     var prefix, suffix, filepath;
 
     if (file.isNull())   return;
-    if (file.isStream()) return this.emit('error', new gutil.PluginError('gulp-manifest',  'Streaming not supported'));
+    if (file.isStream()) return this.emit('error', new PluginError('gulp-manifest',  'Streaming not supported'));
 
     prefix = slash(options.prefix || '');
     suffix = slash(options.suffix || '');
@@ -97,7 +99,7 @@ function manifest(options) {
         var firstSpace = file.indexOf(' ');
 
         if (firstSpace === -1) {
-          return gutil.log('Invalid format for FALLBACK entry', file);
+          return log('Invalid format for FALLBACK entry', file);
         }
 
         contents.push(
@@ -121,7 +123,7 @@ function manifest(options) {
       contents.push('# hash: ' + hasher.digest("hex"));
     }
 
-    var manifestFile = new gutil.File({
+    var manifestFile = new Vinyl({
       cwd: cwd,
       base: cwd,
       path: path.join(cwd, filename),

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "gulp": "^3.9.0"
   },
   "dependencies": {
-    "gulp-util": "~2.2.6",
+    "fancy-log": "^1.3.2",
     "minimatch": "~2.0.1",
+    "plugin-error": "^1.0.0",
     "slash": "^1.0.0",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "vinyl": "^2.1.0"
   },
   "bugs": {
     "url": "https://github.com/hillmanov/gulp-manifest/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gulp-manifest",
-  "version": "0.1.1",
+  "name": "gulp-manifest2",
+  "version": "0.1.2",
   "description": "Generate HTML5 Cache Manifest files",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hillmanov/gulp-manifest"
+    "url": "https://github.com/timolawl/gulp-manifest"
   },
   "keywords": [
     "gulp",
@@ -18,7 +18,7 @@
     "appcache"
   ],
   "author": {
-    "name": "Scott Hillman"
+    "name": "Tim Chiang"
   },
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -37,7 +37,7 @@
     "vinyl": "^2.1.0"
   },
   "bugs": {
-    "url": "https://github.com/hillmanov/gulp-manifest/issues"
+    "url": "https://github.com/timolawl/gulp-manifest/issues"
   },
-  "homepage": "https://github.com/hillmanov/gulp-manifest"
+  "homepage": "https://github.com/timolawl/gulp-manifest"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulp-manifest2",
+  "name": "gulp-manifest3",
   "version": "0.1.2",
   "description": "Generate HTML5 Cache Manifest files",
   "main": "index.js",

--- a/test/main.js
+++ b/test/main.js
@@ -3,13 +3,13 @@ var fs             = require('fs'),
     es             = require('event-stream'),
     slash          = require('slash'),
     should         = require('should'),
-    gutil          = require('gulp-util'),
+    Vinyl          = require('vinyl'),
     gulp           = require('gulp'),
     mocha          = require('mocha'),
     manifestPlugin = require('../');
 
 function createFakeFile(filename) {
-  return new gutil.File({
+  return new Vinyl({
     path: path.resolve('test/fixture/' + filename),
     cwd: path.resolve('test/'),
     base: path.resolve('test/fixture/'),
@@ -36,7 +36,7 @@ describe('gulp-manifest', function() {
     });
 
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
       data.relative.should.eql('cache.manifest');
 
       var contents = data.contents.toString();
@@ -68,7 +68,7 @@ describe('gulp-manifest', function() {
       done();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
         path: path.resolve('test\\fixture\\hello.js'),
         cwd: path.resolve('test/'),
         base: path.resolve('test/'),
@@ -153,7 +153,7 @@ describe('gulp-manifest', function() {
     var contents = '',
         relatives = [];
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
       relatives.push(data.relative);
       contents += data.contents.toString();
     });
@@ -180,7 +180,7 @@ describe('gulp-manifest', function() {
       done();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: path.resolve('test\\fixture\\hello.js'),
       cwd: path.resolve('test/'),
       base: path.resolve('test/'),
@@ -202,7 +202,7 @@ describe('gulp-manifest', function() {
     });
     stream.once('end', done);
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: path.resolve('test\\fixture\\hello.js'),
       cwd: path.resolve('test/'),
       base: path.resolve('test/'),
@@ -285,7 +285,7 @@ describe('gulp-manifest', function() {
       done();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: slash(filepath),
       cwd: path.resolve('test/'),
       base: './',
@@ -311,7 +311,7 @@ describe('gulp-manifest', function() {
       done();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: slash(basePath + '\\test\\fixture\\hello.js'),
       cwd: path.resolve('test/'),
       base: path.resolve('./'),
@@ -332,7 +332,7 @@ describe('gulp-manifest', function() {
 
     var contents = '', relatives = [];
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
 
       relatives.push(data.relative);
       contents += data.contents.toString();
@@ -368,7 +368,7 @@ describe('gulp-manifest', function() {
 
     var contents = '', relatives = [];
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
 
       relatives.push(data.relative);
       contents += data.contents.toString();
@@ -408,7 +408,7 @@ describe('gulp-manifest', function() {
       done();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: 'baz',
       base: path.resolve('./'),
       contents: new Buffer('notimportant')
@@ -434,7 +434,7 @@ describe('gulp-manifest', function() {
       done();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: 'baz',
       base: path.resolve('./'),
       contents: new Buffer('notimportant')
@@ -453,7 +453,7 @@ describe('gulp-manifest', function() {
 
     var contents = '', count = 0;
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
       contents += data.contents.toString();
     });
 
@@ -462,7 +462,7 @@ describe('gulp-manifest', function() {
       done();
     });
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       path: 'foobar',
       base: path.resolve('./'),
       contents: new Buffer('notimportant')
@@ -478,7 +478,7 @@ describe('gulp-manifest', function() {
     });
 
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
       data.relative.should.eql('cache.manifest');
 
       var contents = data.contents.toString();
@@ -498,7 +498,7 @@ describe('gulp-manifest', function() {
     });
 
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
       data.relative.should.eql('cache.manifest');
 
       var contents = data.contents.toString();
@@ -519,7 +519,7 @@ describe('gulp-manifest', function() {
     });
 
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
       data.relative.should.eql('cache.manifest');
 
       var contents = data.contents.toString();
@@ -540,7 +540,7 @@ describe('gulp-manifest', function() {
     });
 
     stream.on('data', function(data) {
-      data.should.be.an.instanceOf(gutil.File);
+      data.should.be.an.instanceOf(Vinyl);
       data.relative.should.eql('cache.manifest');
 
       var contents = data.contents.toString();


### PR DESCRIPTION
Gulp's next major version (v4.0) is no longer compatible with gulp-util. Dependency on gulp-util has been removed in favor of gulp-util's own upstream dependencies. See https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5.